### PR TITLE
Updates for cross-compiling OpenMV-IDE

### DIFF
--- a/scripts/deployqt.py
+++ b/scripts/deployqt.py
@@ -145,6 +145,19 @@ def copy_qt_libs(target_qt_prefix_path, qt_libs_dir, qt_plugin_dir, qt_import_di
         else:
             shutil.copy(library, lib_dest)
 
+    #OPENMV-DIFF#
+    # Additions to support fonts for cross-compiled platforms like RPi:
+    if common.is_linux_platform() and os.path.exists(os.path.join(qt_libs_dir, 'fonts')):
+        print "Copying fonts..."
+        fonts = glob(os.path.join(qt_libs_dir, 'fonts/*'))
+        fonts_dest = os.path.join(target_qt_prefix_path, 'lib/fonts')
+        if not os.path.exists(fonts_dest):
+            os.makedirs(fonts_dest)
+        for font in fonts:
+            print font, '->', fonts_dest
+            shutil.copy(font, fonts_dest)
+    #OPENMV-DIFF#
+
     print "Copying plugins:", plugins
     for plugin in plugins:
         target = os.path.join(target_qt_prefix_path, 'plugins', plugin)

--- a/share/qtcreator/translations/translations.pro
+++ b/share/qtcreator/translations/translations.pro
@@ -13,9 +13,20 @@ defineReplace(prependAll) {
 }
 
 XMLPATTERNS = $$shell_path($$[QT_INSTALL_BINS]/xmlpatterns)
-LUPDATE = $$shell_path($$[QT_INSTALL_BINS]/lupdate) -locations relative -no-ui-lines -no-sort
-LRELEASE = $$shell_path($$[QT_INSTALL_BINS]/lrelease)
-LCONVERT = $$shell_path($$[QT_INSTALL_BINS]/lconvert)
+#OPENMV-DIFF#
+# Note: while this is technically a difference specific to OPENMV to support
+# cross-compiling, it's broken in the original QtCreator code and I will be
+# submitting it to Qt as a patch since the translation tools for building
+# translations should always be found on the host system's bin path, not the
+# target system's install path:
+#LUPDATE = $$shell_path($$[QT_INSTALL_BINS]/lupdate) -locations relative -no-ui-lines -no-sort
+#LRELEASE = $$shell_path($$[QT_INSTALL_BINS]/lrelease)
+#LCONVERT = $$shell_path($$[QT_INSTALL_BINS]/lconvert)
+#OPENMV-DIFF#
+LUPDATE = $$shell_path($$[QT_HOST_BINS]/lupdate) -locations relative -no-ui-lines -no-sort
+LRELEASE = $$shell_path($$[QT_HOST_BINS]/lrelease)
+LCONVERT = $$shell_path($$[QT_HOST_BINS]/lconvert)
+#OPENMV-DIFF#
 
 wd = $$replace(IDE_SOURCE_TREE, /, $$QMAKE_DIR_SEP)
 

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -8,6 +8,10 @@ DESTDIR = $$IDE_APP_PATH
 VERSION = $$QTCREATOR_VERSION
 QT -= testlib
 
+#OPENMV-DIFF#
+QT += qml
+#OPENMV-DIFF#
+
 HEADERS += ../tools/qtcreatorcrashhandler/crashhandlersetup.h
 SOURCES += main.cpp ../tools/qtcreatorcrashhandler/crashhandlersetup.cpp
 

--- a/src/rpath.pri
+++ b/src/rpath.pri
@@ -6,6 +6,11 @@ macx {
     QMAKE_RPATHDIR += \$\$ORIGIN
     QMAKE_RPATHDIR += \$\$ORIGIN/..
     QMAKE_RPATHDIR += \$\$ORIGIN/../$$IDE_LIBRARY_BASENAME/qtcreator
+#OPENMV-DIFF#
+# Padding is needed to facilitate chrpath for the longer paths involved with
+# cross-compiled targets (see qt-creator/scripts/common.py):
+    QMAKE_RPATHDIR += ______________________________PADDING______________________________
+#OPENMV-DIFF#
     IDE_PLUGIN_RPATH = $$join(QMAKE_RPATHDIR, ":")
 
     QMAKE_LFLAGS += -Wl,-z,origin \'-Wl,-rpath,$${IDE_PLUGIN_RPATH}\'


### PR DESCRIPTION
These commits are the changes necessary to update the project for cross-compiling, particularly for the Raspberry Pi.

Both the qt-creator and openmv-ide repositories need updates.  I am sending two pull requests, one for each.  You'll probably want to apply the qt-creator pull request first, then the one for openmv-ide.

Notes on how to cross-compile for the Raspberry Pi have been checked into the root of the openmv-ide project as a text document.  I will be looking at posting a Release for the Raspberry Pi on my forked openmv-ide repository on GitHub so that users will have it available without needing to compile it first.
