### PR TITLE
Fix Open File Dialog not showing any files. (Windows, Chinese)

### DIFF
--- a/share/qtcreator/translations/qtcreator_zh_CN.ts
+++ b/share/qtcreator/translations/qtcreator_zh_CN.ts
@@ -669,7 +669,7 @@
         <location line="+22"/>
         <source>All Files (*.*)</source>
         <comment>On Windows</comment>
-        <translation>全部文件 （*。*）</translation>
+        <translation>全部文件 (*.*)</translation>
     </message>
     <message>
         <location line="+2"/>

--- a/share/qtcreator/translations/qtcreator_zh_TW.ts
+++ b/share/qtcreator/translations/qtcreator_zh_TW.ts
@@ -669,7 +669,7 @@
         <location line="+22"/>
         <source>All Files (*.*)</source>
         <comment>On Windows</comment>
-        <translation>全部文件 （*。*）</translation>
+        <translation>全部文件 (*.*)</translation>
     </message>
     <message>
         <location line="+2"/>


### PR DESCRIPTION
## The Problem
On Windows, when the OpenMV IDE is set to the Chinese language, the Open File Dialog does not display any files.

## Solution
Fixed the format of QFileDialog filter string (using half-width parentheses and dots instead of full-width).

## Screenshot
Before fixing:
<img src="https://github.com/openmv/qt-creator/assets/64732488/df87e895-7639-462e-a937-b763b853d729" width="50%">

After fixing:
<img src="https://github.com/openmv/qt-creator/assets/64732488/872c11c6-d680-4b95-ab9d-cc6279f37067" width="50%">

## Note
This change does not affect the Linux and macOS versions of the OpenMV IDE.
