### PR TITLE
Fix FORCE_FULL_SCREEN macro

### DIFF
--- a/src/plugins/openmv/openmvplugin.cpp
+++ b/src/plugins/openmv/openmvplugin.cpp
@@ -428,8 +428,8 @@ bool OpenMVPlugin::initialize(const QStringList &arguments, QString *errorMessag
     if(true)
     #else
     if(arguments.contains(QStringLiteral("-full_screen")))
-    {
     #endif
+    {
         connect(ExtensionSystem::PluginManager::instance(), &ExtensionSystem::PluginManager::initializationDone, this, [] {
             QAction *action = Core::ActionManager::command(Core::Constants::TOGGLE_FULLSCREEN)->action();
 


### PR DESCRIPTION
## The Problem
Syntax errors occur when the FORCE_FULL_SCREEN macro is defined due to a misplaced left brace in the code's conditional statement.

## Solution
Repositioned the left brace for correct syntax.
