### PR TITLE
change blhost timeout 60000 to 120000

### DIFF
--- a/src/plugins/openmv/tools/imx.cpp
+++ b/src/plugins/openmv/tools/imx.cpp
@@ -884,7 +884,7 @@ bool imxDownloadBootloaderAndFirmware(QJsonObject &obj, bool forceFlashFSErase, 
                                QStringLiteral("-u") <<
                                obj.value(QStringLiteral("blhost_pidvid")).toString() <<
                                QStringLiteral("-t") <<
-                               QStringLiteral("60000") <<
+                               QStringLiteral("120000") <<
                                QStringLiteral("--") <<
                                QStringLiteral("flash-erase-region") <<
                                obj.value(QStringLiteral("blhost_disk_address")).toString() <<
@@ -930,7 +930,7 @@ bool imxDownloadBootloaderAndFirmware(QJsonObject &obj, bool forceFlashFSErase, 
                                QStringLiteral("-u") <<
                                obj.value(QStringLiteral("blhost_pidvid")).toString() <<
                                QStringLiteral("-t") <<
-                               QStringLiteral("60000") <<
+                               QStringLiteral("120000") <<
                                QStringLiteral("--") <<
                                QStringLiteral("flash-erase-region") <<
                                obj.value(QStringLiteral("blhost_firmware_address")).toString() <<
@@ -1243,7 +1243,7 @@ bool imxDownloadFirmware(QJsonObject &obj, bool forceFlashFSErase, bool justEras
                                QStringLiteral("-u") <<
                                obj.value(QStringLiteral("blhost_pidvid")).toString() <<
                                QStringLiteral("-t") <<
-                               QStringLiteral("60000") <<
+                               QStringLiteral("120000") <<
                                QStringLiteral("--") <<
                                QStringLiteral("flash-erase-region") <<
                                obj.value(QStringLiteral("blhost_disk_address")).toString() <<
@@ -1289,7 +1289,7 @@ bool imxDownloadFirmware(QJsonObject &obj, bool forceFlashFSErase, bool justEras
                                QStringLiteral("-u") <<
                                obj.value(QStringLiteral("blhost_pidvid")).toString() <<
                                QStringLiteral("-t") <<
-                               QStringLiteral("60000") <<
+                               QStringLiteral("120000") <<
                                QStringLiteral("--") <<
                                QStringLiteral("flash-erase-region") <<
                                obj.value(QStringLiteral("blhost_firmware_address")).toString() <<


### PR DESCRIPTION
blhost always take 70 seconds, and 60 seconds  always failed. It's better to use 120 seconds.

"/Applications/OpenMV IDE.app/Contents/Resources/blhost/mac/blhost" -u 0x15A2,0x0073 -t 60000 -- flash-erase-region 0x60400000 0x00400000
Inject command 'flash-erase-region'
sendCommandGetResponse.readPacket error 5.
Response status = 10004 (0x2714) No response packet from target device.