### PR TITLE
openmv: Fix USB DBG V4.8.1 connection on Mac. 

### DIFF
--- a/src/plugins/openmv/openmvpluginconnect.cpp
+++ b/src/plugins/openmv/openmvpluginconnect.cpp
@@ -1537,6 +1537,7 @@ void OpenMVPlugin::connectClicked(bool forceBootloader,
         }
 
         bool isOldVidPid = false;
+        bool isTinyUSBHSV1Protocol = false;
         bool isOpenMVDfu = false;
         bool isIMX = false;
         bool isAlif = false;
@@ -1560,6 +1561,8 @@ void OpenMVPlugin::connectClicked(bool forceBootloader,
             if (arduinoPort.hasVendorIdentifier() && arduinoPort.hasProductIdentifier())
             {
                 isOldVidPid = (arduinoPort.vendorIdentifier() == OPENMVCAM_VID) && (arduinoPort.productIdentifier() == OPENMVCAM_PID);
+                isTinyUSBHSV1Protocol = ((arduinoPort.vendorIdentifier() == OPENMVCAM_VID_NEW) && (arduinoPort.productIdentifier() == OPENMVCAM_RT1062_PID)) ||
+                                        ((arduinoPort.vendorIdentifier() == OPENMVCAM_VID_NEW) && (arduinoPort.productIdentifier() == OPENMVCAM_AE3_PID));
                 isArduinoDFU = isBootloaderType(m_firmwareSettings, arduinoPort.vendorIdentifier(), arduinoPort.productIdentifier(), QStringLiteral("arduino_dfu"));
                 isBossac = isBootloaderType(m_firmwareSettings, arduinoPort.vendorIdentifier(), arduinoPort.productIdentifier(), QStringLiteral("bossac"));
                 isPicotool = isBootloaderType(m_firmwareSettings, arduinoPort.vendorIdentifier(), arduinoPort.productIdentifier(), QStringLiteral("picotool"));
@@ -1763,7 +1766,18 @@ void OpenMVPlugin::connectClicked(bool forceBootloader,
             connect(m_iodevice, &OpenMVPluginIO::protocolVersionDone,
                     &loop, &QEventLoop::quit);
 
-            m_iodevice->checkProtocolVerison(m_reconnects & 1);
+            // For unknown reasons, sending the special check packet on mac does not work
+            // correctly unless it's split on the highspeed cameras. The USB packet is indeed
+            // sent on the bus, but, the camera will lockup. This workout exist for all high speed
+            // capable cameras using the V1 protocol with TinyUSB.
+            if (isTinyUSBHSV1Protocol && Utils::HostOsInfo::isMacHost())
+            {
+                m_iodevice->checkProtocolVerison(true);
+            }
+            else
+            {
+                m_iodevice->checkProtocolVerison(m_reconnects & 1);
+            }
 
             loop.exec();
         }

--- a/src/plugins/openmv/openmvpluginio.cpp
+++ b/src/plugins/openmv/openmvpluginio.cpp
@@ -653,6 +653,14 @@ void OpenMVPluginIO::commandResult(const OpenMVPluginSerialPortCommandResult &co
                 }
                 case CHECK_PROTOCOL_VERSION_CPL_SPLIT:
                 {
+                    if(data.size())
+                    {
+                        // V1 Protocol response will be 0/1.
+                        // V2 Protocol response will be the proto sync.
+                        m_v2ProtocolEnabled = deserializeWord(data) == OMVProto::SYNC_WORD;
+                        m_port->enableV2Protocol(m_v2ProtocolEnabled);
+                    }
+
                     break;
                 }
                 case USBDBG_FW_VERSION_CPL:
@@ -1166,6 +1174,8 @@ void OpenMVPluginIO::commandResult(const OpenMVPluginSerialPortCommandResult &co
                     }
                     case CHECK_PROTOCOL_VERSION_CPL_SPLIT:
                     {
+                        m_v2ProtocolEnabled = false;
+                        m_port->enableV2Protocol(m_v2ProtocolEnabled);
                         break;
                     }
                     case USBDBG_FW_VERSION_CPL:
@@ -1602,28 +1612,32 @@ void OpenMVPluginIO::checkProtocolVerison(bool splitCommand)
 
     // On Mac for the RT1062 and AE3, they cannot handle receiving all 4 commands at once.
     // Splitting the command up into UDSBG_LEN sized commands seems to work around this...
+    //
+    // Note that you cannot send the split packet first for STM32 USBDBG as it will crash them...
     int len = SCRIPT_RUNNING_RESPONSE_LEN;
 
     if (splitCommand) {
-        while (buffer.size() > USBDBG_LEN) {
+        for (int i = 0, ii = buffer.size(); i < ii; i += USBDBG_LEN) {
             QByteArray part = buffer.left(USBDBG_LEN);
             buffer = buffer.mid(USBDBG_LEN);
             m_postedQueue.enqueue(OpenMVPluginSerialPortCommand(part,
-                                                                len,
+                                                                (i == (ii - USBDBG_LEN)) ? len : 0,
                                                                 SCRIPT_RUNNING_START_DELAY,
                                                                 SCRIPT_RUNNING_END_DELAY,
-                                                                true, false, len > 0));
+                                                                true, false, i == 0));
             m_completionQueue.enqueue(CHECK_PROTOCOL_VERSION_CPL_SPLIT);
-            len = 0;
         }
     }
+    else
+    {
+        m_postedQueue.enqueue(OpenMVPluginSerialPortCommand(buffer,
+                                                            len,
+                                                            SCRIPT_RUNNING_START_DELAY,
+                                                            SCRIPT_RUNNING_END_DELAY,
+                                                            true, false, len > 0));
+        m_completionQueue.enqueue(CHECK_PROTOCOL_VERSION_CPL);
+    }
 
-    m_postedQueue.enqueue(OpenMVPluginSerialPortCommand(buffer,
-                                                        len,
-                                                        SCRIPT_RUNNING_START_DELAY,
-                                                        SCRIPT_RUNNING_END_DELAY,
-                                                        true, false, len > 0));
-    m_completionQueue.enqueue(CHECK_PROTOCOL_VERSION_CPL);
     command();
 }
 

--- a/src/plugins/openmv/openmvpluginprotocol.cpp
+++ b/src/plugins/openmv/openmvpluginprotocol.cpp
@@ -708,11 +708,15 @@ QByteArray OpenMVPlugin::fixScriptForSensor(QByteArray data, bool notExamples, b
     {
         data = data.replace(QByteArrayLiteral("sensor.set_pixformat(sensor.RGB565)"),
                             QByteArrayLiteral("sensor.set_pixformat(sensor.GRAYSCALE)"));
+        data = data.replace(QByteArrayLiteral(".pixformat(csi.RGB565)"),
+                            QByteArrayLiteral(".pixformat(csi.GRAYSCALE)"));
 
         if(m_sensorType.startsWith(QStringLiteral("HM01B0")))
         {
             data = data.replace(QByteArrayLiteral("sensor.set_framesize(sensor.VGA)"),
                                 QByteArrayLiteral("sensor.set_framesize(sensor.QVGA)"));
+            data = data.replace(QByteArrayLiteral(".framesize(csi.VGA)"),
+                                QByteArrayLiteral(".framesize(csi.QVGA)"));
         }
 
         if((m_sensorType.startsWith(QStringLiteral("BOSON-320"))) ||
@@ -723,6 +727,8 @@ QByteArray OpenMVPlugin::fixScriptForSensor(QByteArray data, bool notExamples, b
         {
             data = data.replace(QByteArrayLiteral("sensor.set_framesize(sensor.VGA)"),
                                 QByteArrayLiteral("sensor.set_framesize(sensor.QVGA)"));
+            data = data.replace(QByteArrayLiteral(".framesize(csi.VGA)"),
+                                QByteArrayLiteral(".framesize(csi.QVGA)"));
         }
 
         if((m_sensorType.startsWith(QStringLiteral("BOSON-640"))) ||
@@ -730,6 +736,8 @@ QByteArray OpenMVPlugin::fixScriptForSensor(QByteArray data, bool notExamples, b
         {
             data = data.replace(QByteArrayLiteral("sensor.set_framesize(sensor.QVGA)"),
                                 QByteArrayLiteral("sensor.set_framesize(sensor.VGA)"));
+            data = data.replace(QByteArrayLiteral(".framesize(csi.QVGA)"),
+                                QByteArrayLiteral(".framesize(csi.VGA)"));
         }
 
         if((m_sensorType.startsWith(QStringLiteral("GENX320-S"))) ||
@@ -739,6 +747,10 @@ QByteArray OpenMVPlugin::fixScriptForSensor(QByteArray data, bool notExamples, b
                                 QByteArrayLiteral("sensor.set_framesize(sensor.B320X320)"));
             data = data.replace(QByteArrayLiteral("sensor.set_framesize(sensor.VGA)"),
                                 QByteArrayLiteral("sensor.set_framesize(sensor.B320X320)"));
+            data = data.replace(QByteArrayLiteral(".framesize(csi.QVGA)"),
+                                QByteArrayLiteral(".framesize((320, 320))"));
+            data = data.replace(QByteArrayLiteral(".framesize(csi.VGA)"),
+                                QByteArrayLiteral(".framesize((320, 320))"));
         }
     }
 
@@ -749,6 +761,8 @@ QByteArray OpenMVPlugin::fixScriptForSensor(QByteArray data, bool notExamples, b
     {
         data = data.replace(QByteArrayLiteral("sensor.set_framesize(sensor.QVGA)"),
                             QByteArrayLiteral("sensor.set_framesize(sensor.VGA)"));
+        data = data.replace(QByteArrayLiteral(".framesize(csi.QVGA)"),
+                            QByteArrayLiteral(".framesize(csi.VGA)"));
     }
 
     return data;

--- a/src/plugins/openmv/openmvpluginprotocol.cpp
+++ b/src/plugins/openmv/openmvpluginprotocol.cpp
@@ -142,12 +142,15 @@ void OpenMVPlugin::setPortPath(bool silent)
         {
             const QString rootPath = pair.first;
             const QString serialNumber = pair.second;
+            QByteArray serialNumberBytes = serialNumber.toUtf8();
+            std::reverse(serialNumberBytes.begin(), serialNumberBytes.end());
+            const QString serialNumberRev = QString::fromUtf8(serialNumberBytes);
 
             if((((m_major < OPENMV_DISK_ADDED_MAJOR)
                   || ((m_major == OPENMV_DISK_ADDED_MAJOR) && (m_minor < OPENMV_DISK_ADDED_MINOR))
                   || ((m_major == OPENMV_DISK_ADDED_MAJOR) && (m_minor == OPENMV_DISK_ADDED_MINOR) && (m_patch < OPENMV_DISK_ADDED_PATCH)))
-                 || QFile::exists(rootPath + QStringLiteral(OPENMV_DISK_ADDED_NAME)))
-                && (serialNumber.toLower() == m_portDriveSerialNumber.toLower()))
+                  || QFile::exists(rootPath + QStringLiteral(OPENMV_DISK_ADDED_NAME)))
+                && ((serialNumber.toLower() == m_portDriveSerialNumber.toLower()) || (serialNumberRev.toLower() == m_portDriveSerialNumber.toLower())))
             {
                 drives.append(rootPath);
             }

--- a/src/plugins/openmv/openmvpluginserialport.h
+++ b/src/plugins/openmv/openmvpluginserialport.h
@@ -46,6 +46,10 @@
 #define OPENMVCAM_VID           0x1209
 #define OPENMVCAM_PID           0xABD1
 
+#define OPENMVCAM_VID_NEW       0x37C5
+#define OPENMVCAM_RT1062_PID    0x1060
+#define OPENMVCAM_AE3_PID       0x16E3
+
 #define ARDUINOCAM_VID          0x2341
 #define ARDUINOCAM_PH7_PID      0x005B
 #define ARDUINOCAM_NRF_PID      0x005A


### PR DESCRIPTION
Loading firmware for the RT1062 and AE3 with V4.8.1 was broken due weird USB packet handling by TinyUSB with the V1 DBG protocol.